### PR TITLE
Fixed function coverage logging when callgraph files are enabled.

### DIFF
--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -93,7 +93,7 @@ function initRuntime(asm) {
 #include "coverage.js"
 
 // Install the code coverage execution handler.
-asmLibraryArg['log_execution'] = COV_log_execution;
+wasmImports['log_execution'] = COV_log_execution;
 #endif
 
 // Initialize wasm (asynchronous)

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -944,7 +944,7 @@ function instantiateAsync(binary, binaryFile, imports, callback) {
 function createWasm() {
 #if EMIT_SYMBOL_GRAPH_JSON
   // Install the code coverage execution handler.
-  asmLibraryArg['log_execution'] = COV_log_execution;
+  wasmImports['log_execution'] = COV_log_execution;
 #endif
 
   // prepare imports


### PR DESCRIPTION
The name of `asmLibraryArg` has been changed to `wasmImports`. This change was not updated in the code for the function coverage logging.