### PR TITLE
Backport fix for: Reverse deps with -sERROR_ON_UNDEFINED_SYMBOLS=0

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -541,7 +541,7 @@ def get_js_sym_info():
     """
     library_syms = generate_js_sym_info()
 
-    write_file(filename, json.dumps(library_syms, separators=(',', ':')))
+    write_file(filename, json.dumps(library_syms, separators=(',', ':'), indent=2))
 
   # We need to use a separate lock here for symbol lists because, unlike with system libraries,
   # it's normally for these file to get pruned as part of normal operation.  This means that it

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -5198,15 +5198,17 @@ int main() {
     'full_only': [{'EMCC_FORCE_STDLIBS': 'libc,libc++abi,libc++,libmalloc', 'EMCC_ONLY_FORCED_STDLIBS': '1'}, False],
   })
   def test_only_force_stdlibs(self, env, fail):
+    cmd = [EMXX, test_file('hello_libcxx.cpp')]
     with env_modify(env):
-      err = self.run_process([EMXX, test_file('hello_libcxx.cpp'), '-sWARN_ON_UNDEFINED_SYMBOLS=0'], stderr=PIPE).stderr
-      if 'EMCC_ONLY_FORCED_STDLIBS' in env:
-        self.assertContained('EMCC_ONLY_FORCED_STDLIBS is deprecated', err)
       if fail:
-        output = self.run_js('a.out.js', assert_returncode=NON_ZERO)
-        self.assertContained('missing function', output)
+        err = self.expect_fail(cmd)
+        self.assertContained('undefined symbol: malloc', err)
       else:
-        self.assertContained('hello, world!', self.run_js('a.out.js'))
+        err = self.run_process(cmd, stderr=PIPE).stderr
+        if 'EMCC_ONLY_FORCED_STDLIBS' in env:
+          self.assertContained('EMCC_ONLY_FORCED_STDLIBS is deprecated', err)
+        else:
+          self.assertContained('hello, world!', self.run_js('a.out.js'))
 
   def test_only_force_stdlibs_2(self):
     create_file('src.cpp', r'''
@@ -12048,6 +12050,22 @@ exec "$@"
   def test_main_module_no_undefined(self):
     # Test that ERROR_ON_UNDEFINED_SYMBOLS works with MAIN_MODULE.
     self.do_runf(test_file('hello_world.c'), emcc_args=['-sMAIN_MODULE', '-sERROR_ON_UNDEFINED_SYMBOLS'])
+
+  def test_reverse_deps_allow_undefined(self):
+    # Check that reverse deps are still included even when -sERROR_ON_UNDEFINED_SYMBOLS=0.
+    create_file('test.c', '''
+    #include <assert.h>
+    #include <stdio.h>
+    #include <netdb.h>
+
+    int main() {
+      // Reference in getaddrinfo which has reverse deps on malloc and htons
+      // We expect these to be exported even when -sERROR_ON_UNDEFINED_SYMBOLS=0.
+      printf("%p\\n", &getaddrinfo);
+      return 0;
+    }
+    ''')
+    self.do_runf('test.c', emcc_args=['-sERROR_ON_UNDEFINED_SYMBOLS=0'])
 
   @parameterized({
     'relocatable': ('-sRELOCATABLE',),

--- a/tools/building.py
+++ b/tools/building.py
@@ -135,10 +135,7 @@ def create_stub_object(external_symbols):
   stubfile = shared.get_temp_files().get('libemscripten_js_symbols.so').name
   stubs = ['#STUB']
   for name, deps in external_symbols.items():
-    if settings.ERROR_ON_UNDEFINED_SYMBOLS:
-      stubs.append('%s: %s' % (name, ','.join(deps)))
-    else:
-      stubs.append(name)
+    stubs.append('%s: %s' % (name, ','.join(deps)))
   utils.write_file(stubfile, '\n'.join(stubs))
   return stubfile
 


### PR DESCRIPTION
This PR backports the fix https://github.com/emscripten-core/emscripten/pull/19352 from emscripten-core to our version of emscripten. This is done to fix the Unity bug: [UUM-74261](https://jira.unity3d.com/browse/UUM-74261)


Description from the original PR:
> The change to `test_only_force_stdlibs` was needed because the failure case is now a build time rather than runtime error.
> 
> Using `-sWARN_ON_UNDEFINED_SYMBOLS=0` (which implicitly sets `ERROR_ON_UNDEFINED_SYMBOLS=0` too) cannot prevent/delay errors when certain types of symbols are missing.  For example the linker will always error on missing data symbols.  After this change the linker will also always error on missing revert dependencies (of which malloc is one in this test case).
> 
> Fixes: #19234